### PR TITLE
Reject first() when stream emits an error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ event does not pass any data.
 If you do not pass a custom event name, then it will wait for the first "data"
 event and resolve with a string containing the first data chunk.
 
+The promise will reject if the stream emits an error – unless you're waiting for
+the "error" event, in which case it will resolve.
+
 The promise will reject once the stream closes – unless you're waiting for the
 "close" event, in which case it will resolve.
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -84,6 +84,13 @@ function first(EventEmitterInterface $stream, $event = 'data')
         };
         $stream->on($event, $listener);
 
+        if ($event !== 'error') {
+            $stream->on('error', function ($error) use ($stream, $event, $listener, $reject) {
+                $stream->removeListener($event, $listener);
+                $reject(new \RuntimeException('An error occured on the underlying stream while waiting for event', 0, $error));
+            });
+        }
+
         $stream->on('close', function () use ($stream, $event, $listener, $reject) {
             $stream->removeListener($event, $listener);
             $reject(new \RuntimeException('Stream closed'));

--- a/tests/FirstTest.php
+++ b/tests/FirstTest.php
@@ -76,14 +76,14 @@ class FirstTest extends TestCase
         $this->expectPromiseResolveWith('hello', $promise);
     }
 
-    public function testEmittingErrorOnStreamDoesNothing()
+    public function testEmittingErrorOnStreamWillReject()
     {
         $stream = new ThroughStream();
         $promise = Stream\first($stream);
 
         $stream->emit('error', array(new \RuntimeException('test')));
 
-        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+        $this->expectPromiseReject($promise);
     }
 
     public function testEmittingErrorResolvesWhenWaitingForErrorEvent()


### PR DESCRIPTION
The `buffer()` and `all()` functions already explicitly reject when the underlying stream emits an error event. The error event will always be followed by an immediate close event.

This simple PR updates the `first()` function to also explicitly reject when the underlying stream emits an error event. This allows consumers to get access to the underlying `Exception`, which the following close event does not report.