### PR TITLE
Fix `all()` to assume null values if no event data is passed

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -125,7 +125,7 @@ function all(EventEmitterInterface $stream, $event = 'data')
     }
 
     $buffer = array();
-    $bufferer = function ($data) use (&$buffer) {
+    $bufferer = function ($data = null) use (&$buffer) {
         $buffer []= $data;
     };
     $stream->on($event, $bufferer);

--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -68,6 +68,19 @@ class AllTest extends TestCase
         $this->expectPromiseResolveWith(array('hello', 'world'), $promise);
     }
 
+    public function testEmittingCustomEventOnStreamResolvesWithArrayOfCustomEventData()
+    {
+        $stream = new ThroughStream();
+        $promise = Stream\all($stream, 'a');
+
+        $stream->emit('a', array('hello'));
+        $stream->emit('b', array('ignored'));
+        $stream->emit('a');
+        $stream->close();
+
+        $this->expectPromiseResolveWith(array('hello', null), $promise);
+    }
+
     public function testEmittingErrorOnStreamRejects()
     {
         $stream = new ThroughStream();


### PR DESCRIPTION
Resolves / closes #10 