### PR TITLE
Support object streams by buffering original write chunks in array

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively, you can also refer to them with their fully-qualified name:
 
 ```php
 \React\Promise\Stream\buffer(…);
-``` 
+```
 
 ### buffer()
 
@@ -190,8 +190,9 @@ a `Promise` which resolves with a `WritableStreamInterface`.
 
 This function returns a writable stream instance (implementing `WritableStreamInterface`)
 right away which acts as a proxy for the future promise resolution.
+Any writes to this instance will be buffered in memory for when the promise resolves.
 Once the given Promise resolves with a `WritableStreamInterface`, any data you
-wrote to the proxy will be piped to the inner stream.
+have written to the proxy will be forwarded transparently to the inner stream.
 
 ```php
 //$promise = someFunctionWhichResolvesWithAStream();

--- a/src/UnwrapWritableStream.php
+++ b/src/UnwrapWritableStream.php
@@ -16,7 +16,7 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
 {
     private $promise;
     private $stream;
-    private $buffer = '';
+    private $buffer = array();
     private $closed = false;
     private $ending = false;
 
@@ -69,10 +69,15 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
                 $stream->on('close', array($out, 'close'));
                 $out->on('close', array($stream, 'close'));
 
-                if ($buffer !== '') {
+                if ($buffer) {
                     // flush buffer to stream and check if its buffer is not exceeded
-                    $drained = $stream->write($buffer) !== false;
-                    $buffer = '';
+                    $drained = true;
+                    foreach ($buffer as $chunk) {
+                        if (!$stream->write($chunk)) {
+                            $drained = false;
+                        }
+                    }
+                    $buffer = array();
 
                     if ($drained) {
                         // signal drain event, because the output stream previous signalled a full buffer
@@ -109,7 +114,7 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
         }
 
         // append to buffer and signal the buffer is full
-        $this->buffer .= $data;
+        $this->buffer[] = $data;
         return false;
     }
 
@@ -128,7 +133,7 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
 
         // append to buffer
         if ($data !== null) {
-            $this->buffer .= $data;
+            $this->buffer[] = $data;
         }
     }
 
@@ -143,7 +148,7 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
             return;
         }
 
-        $this->buffer = '';
+        $this->buffer = array();
         $this->ending = true;
         $this->closed = true;
 


### PR DESCRIPTION
The `unwrapWritable()` function now buffers all outstanding writes in an array instead of assuming strings. This means it now supports unwrapping streams that expect non-string values (object stream), such as CSV or NDJON encoders.