### PR TITLE
Improve error reporting by appending previous exception messages

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -67,8 +67,12 @@ function buffer(ReadableStreamInterface $stream, $maxLength = null)
 
         $stream->on('data', $bufferer);
 
-        $stream->on('error', function ($error) use ($reject) {
-            $reject(new \RuntimeException('An error occured on the underlying stream while buffering', 0, $error));
+        $stream->on('error', function (\Exception $e) use ($reject) {
+            $reject(new \RuntimeException(
+                'An error occured on the underlying stream while buffering: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            ));
         });
 
         $stream->on('close', function () use ($resolve, &$buffer) {
@@ -78,7 +82,7 @@ function buffer(ReadableStreamInterface $stream, $maxLength = null)
         $reject(new \RuntimeException('Cancelled buffering'));
     });
 
-    return $promise->then(null, function ($error) use (&$buffer, $bufferer, $stream) {
+    return $promise->then(null, function (\Exception $error) use (&$buffer, $bufferer, $stream) {
         // promise rejected => clear buffer and buffering
         $buffer = '';
         $stream->removeListener('data', $bufferer);
@@ -140,9 +144,13 @@ function first(EventEmitterInterface $stream, $event = 'data')
         $stream->on($event, $listener);
 
         if ($event !== 'error') {
-            $stream->on('error', function ($error) use ($stream, $event, $listener, $reject) {
+            $stream->on('error', function (\Exception $e) use ($stream, $event, $listener, $reject) {
                 $stream->removeListener($event, $listener);
-                $reject(new \RuntimeException('An error occured on the underlying stream while waiting for event', 0, $error));
+                $reject(new \RuntimeException(
+                    'An error occured on the underlying stream while waiting for event: ' . $e->getMessage(),
+                    $e->getCode(),
+                    $e
+                ));
             });
         }
 
@@ -207,8 +215,12 @@ function all(EventEmitterInterface $stream, $event = 'data')
     $stream->on($event, $bufferer);
 
     $promise = new Promise\Promise(function ($resolve, $reject) use ($stream, &$buffer) {
-        $stream->on('error', function ($error) use ($reject) {
-            $reject(new \RuntimeException('An error occured on the underlying stream while buffering', 0, $error));
+        $stream->on('error', function (\Exception $e) use ($reject) {
+            $reject(new \RuntimeException(
+                'An error occured on the underlying stream while buffering: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            ));
         });
 
         $stream->on('close', function () use ($resolve, &$buffer) {

--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -86,9 +86,13 @@ class AllTest extends TestCase
         $stream = new ThroughStream();
         $promise = Stream\all($stream);
 
-        $stream->emit('error', array(new \RuntimeException('test')));
+        $stream->emit('error', array(new \RuntimeException('test', 42)));
 
-        $this->expectPromiseReject($promise);
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException(
+            'An error occured on the underlying stream while buffering: test',
+            42,
+            new \RuntimeException('test', 42)
+        )));
     }
 
     public function testEmittingErrorAfterEmittingDataOnStreamRejects()
@@ -97,9 +101,13 @@ class AllTest extends TestCase
         $promise = Stream\all($stream);
 
         $stream->emit('data', array('hello', $stream));
-        $stream->emit('error', array(new \RuntimeException('test')));
+        $stream->emit('error', array(new \RuntimeException('test', 42)));
 
-        $this->expectPromiseReject($promise);
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException(
+            'An error occured on the underlying stream while buffering: test',
+            42,
+            new \RuntimeException('test', 42)
+        )));
     }
 
     public function testCancelPendingStreamWillReject()

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -55,9 +55,13 @@ class BufferTest extends TestCase
         $stream = new ThroughStream();
         $promise = Stream\buffer($stream);
 
-        $stream->emit('error', array(new \RuntimeException('test')));
+        $stream->emit('error', array(new \RuntimeException('test', 42)));
 
-        $this->expectPromiseReject($promise);
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException(
+            'An error occured on the underlying stream while buffering: test',
+            42,
+            new \RuntimeException('test', 42)
+        )));
     }
 
     public function testEmittingErrorAfterEmittingDataOnStreamRejects()
@@ -66,9 +70,13 @@ class BufferTest extends TestCase
         $promise = Stream\buffer($stream);
 
         $stream->emit('data', array('hello', $stream));
-        $stream->emit('error', array(new \RuntimeException('test')));
+        $stream->emit('error', array(new \RuntimeException('test', 42)));
 
-        $this->expectPromiseReject($promise);
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException(
+            'An error occured on the underlying stream while buffering: test',
+            42,
+            new \RuntimeException('test', 42)
+        )));
     }
 
     public function testCancelPendingStreamWillReject()

--- a/tests/FirstTest.php
+++ b/tests/FirstTest.php
@@ -83,9 +83,13 @@ class FirstTest extends TestCase
         $stream = new ThroughStream();
         $promise = Stream\first($stream);
 
-        $stream->emit('error', array(new \RuntimeException('test')));
+        $stream->emit('error', array(new \RuntimeException('test', 42)));
 
-        $this->expectPromiseReject($promise);
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException(
+            'An error occured on the underlying stream while waiting for event: test',
+            42,
+            new \RuntimeException('test', 42)
+        )));
     }
 
     public function testEmittingErrorResolvesWhenWaitingForErrorEvent()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,18 +22,7 @@ class TestCase extends BaseTestCase
         $mock
             ->expects($this->once())
             ->method('__invoke')
-            ->with($this->equalTo($value));
-
-        return $mock;
-    }
-
-    protected function expectCallableOnceParameter($type)
-    {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->isInstanceOf($type));
+            ->with($value);
 
         return $mock;
     }


### PR DESCRIPTION
This changeset improves error reporting by appending previous exception messages. This improves DX by making it easier to see the underlying error causes without having to check the previous exception via `$e->getPrevious()`.

Refs https://github.com/reactphp/socket/pull/271