### PR TITLE
Add badge to show number of project installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PromiseStream
 
 [![CI status](https://github.com/reactphp/promise-stream/workflows/CI/badge.svg)](https://github.com/reactphp/promise-stream/actions)
+[![installs on Packagist](https://img.shields.io/packagist/dt/react/promise-stream?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/promise-stream)
 
 The missing link between Promise-land and Stream-land
 for [ReactPHP](https://reactphp.org/).


### PR DESCRIPTION
This PR adds a badge with the number of installation on packagist to the README.

Builds on top of reactphp/socket#285.
