### PR TITLE
Update test suite to avoid using deprecated functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,6 @@
         "react/promise": "^3 || ^2.1 || ^1.2"
     },
     "require-dev": {
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/promise-timer": "^1.0",
-        "clue/block-react": "^1.0",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }


### PR DESCRIPTION
Builds on top of #20, https://github.com/reactphp/promise-timer/pull/51 and https://github.com/clue/reactphp-block/pull/59
Refs https://github.com/reactphp/socket/pull/296