### PR TITLE
Template params can only have one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Stream\buffer(…);
 
 ### buffer()
 
-The `buffer(ReadableStreamInterface<string> $stream, ?int $maxLength = null): PromiseInterface<string,RuntimeException>` function can be used to
+The `buffer(ReadableStreamInterface<string> $stream, ?int $maxLength = null): PromiseInterface<string>` function can be used to
 create a `Promise` which will be fulfilled with the stream data buffer.
 
 ```php
@@ -84,7 +84,7 @@ React\Promise\Stream\buffer($stream, 1024)->then(function ($contents) {
 
 ### first()
 
-The `first(ReadableStreamInterface|WritableStreamInterface $stream, string $event = 'data'): PromiseInterface<mixed,RuntimeException>` function can be used to
+The `first(ReadableStreamInterface|WritableStreamInterface $stream, string $event = 'data'): PromiseInterface<mixed>` function can be used to
 create a `Promise` which will be fulfilled once the given event triggers for the first time.
 
 ```php
@@ -114,7 +114,7 @@ The promise will be rejected with a `RuntimeException` if it is cancelled.
 
 ### all()
 
-The `all(ReadableStreamInterface|WritableStreamInterface $stream, string $event = 'data'): PromiseInterface<array,RuntimeException>` function can be used to
+The `all(ReadableStreamInterface|WritableStreamInterface $stream, string $event = 'data'): PromiseInterface<array>` function can be used to
 create a `Promise` which will be fulfilled with an array of all the event data.
 
 ```php
@@ -140,7 +140,7 @@ The promise will be rejected with a `RuntimeException` if it is cancelled.
 
 ### unwrapReadable()
 
-The `unwrapReadable(PromiseInterface<ReadableStreamInterface<T>,Exception> $promise): ReadableStreamInterface<T>` function can be used to
+The `unwrapReadable(PromiseInterface<ReadableStreamInterface<T>> $promise): ReadableStreamInterface<T>` function can be used to
 unwrap a `Promise` which will be fulfilled with a `ReadableStreamInterface<T>`.
 
 This function returns a readable stream instance (implementing `ReadableStreamInterface<T>`)
@@ -197,7 +197,7 @@ $loop->addTimer(2.0, function () use ($stream) {
 
 ### unwrapWritable()
 
-The `unwrapWritable(PromiseInterface<WritableStreamInterface<T>,Exception> $promise): WritableStreamInterface<T>` function can be used to
+The `unwrapWritable(PromiseInterface<WritableStreamInterface<T>> $promise): WritableStreamInterface<T>` function can be used to
 unwrap a `Promise` which will be fulfilled with a `WritableStreamInterface<T>`.
 
 This function returns a writable stream instance (implementing `WritableStreamInterface<T>`)

--- a/src/UnwrapReadableStream.php
+++ b/src/UnwrapReadableStream.php
@@ -21,7 +21,7 @@ class UnwrapReadableStream extends EventEmitter implements ReadableStreamInterfa
     /**
      * Instantiate new unwrapped readable stream for given `Promise` which resolves with a `ReadableStreamInterface`.
      *
-     * @param PromiseInterface $promise Promise<ReadableStreamInterface, Exception>
+     * @param PromiseInterface<ReadableStreamInterface> $promise
      */
     public function __construct(PromiseInterface $promise)
     {

--- a/src/UnwrapWritableStream.php
+++ b/src/UnwrapWritableStream.php
@@ -22,7 +22,7 @@ class UnwrapWritableStream extends EventEmitter implements WritableStreamInterfa
     /**
      * Instantiate new unwrapped writable stream for given `Promise` which resolves with a `WritableStreamInterface`.
      *
-     * @param PromiseInterface $promise Promise<WritableStreamInterface, Exception>
+     * @param PromiseInterface<WritableStreamInterface> $promise
      */
     public function __construct(PromiseInterface $promise)
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -45,7 +45,7 @@ use React\Stream\WritableStreamInterface;
  *
  * @param ReadableStreamInterface<string> $stream
  * @param ?int                            $maxLength Maximum number of bytes to buffer or null for unlimited.
- * @return PromiseInterface<string,\RuntimeException>
+ * @return PromiseInterface<string>
  */
 function buffer(ReadableStreamInterface $stream, $maxLength = null)
 {
@@ -121,7 +121,7 @@ function buffer(ReadableStreamInterface $stream, $maxLength = null)
  *
  * @param ReadableStreamInterface|WritableStreamInterface $stream
  * @param string                                          $event
- * @return PromiseInterface<mixed,\RuntimeException>
+ * @return PromiseInterface<mixed>
  */
 function first(EventEmitterInterface $stream, $event = 'data')
 {
@@ -192,7 +192,7 @@ function first(EventEmitterInterface $stream, $event = 'data')
  *
  * @param ReadableStreamInterface|WritableStreamInterface $stream
  * @param string                                          $event
- * @return PromiseInterface<array,\RuntimeException>
+ * @return PromiseInterface<array>
  */
 function all(EventEmitterInterface $stream, $event = 'data')
 {
@@ -296,7 +296,7 @@ function all(EventEmitterInterface $stream, $event = 'data')
  * });
  * ```
  *
- * @param PromiseInterface<ReadableStreamInterface<T>,\Exception> $promise
+ * @param PromiseInterface<ReadableStreamInterface<T>> $promise
  * @return ReadableStreamInterface<T>
  */
 function unwrapReadable(PromiseInterface $promise)
@@ -361,7 +361,7 @@ function unwrapReadable(PromiseInterface $promise)
  * });
  * ```
  *
- * @param PromiseInterface<WritableStreamInterface<T>,\Exception> $promise
+ * @param PromiseInterface<WritableStreamInterface<T>> $promise
  * @return WritableStreamInterface<T>
  */
 function unwrapWritable(PromiseInterface $promise)


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223